### PR TITLE
Add polyG trimming option and fix sample paths after error removal in short-read QC module

### DIFF
--- a/configs/parameters.yaml
+++ b/configs/parameters.yaml
@@ -11,7 +11,7 @@ minqual:    30
 # --- filter_low_qual --- #
 
 dedup:      False
-
+force_poly_g: True
 
 # --- filter_adapters --- #
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -90,12 +90,14 @@ rule filter_low_qual:
     params:
         minqual = config['minqual'],
         dedup = '--dedup' if config['dedup'] else '--dont_eval_duplication',
+        poly_g_flag = ('-g' if config.get('force_poly_g', False) else ''),
         sample = '{sample}',
         out_dir = join(dirs.OUT, '0_lowqual_removal'),
     shell:
         """
         fastp -i {input.fwd} -I {input.rev} -o {output.fwd} -O {output.rev} \
             -q {params.minqual} {params.dedup} --thread {threads} \
+            {params.poly_g_flag} \
             -j {params.out_dir}/{params.sample}.json \
             -h {params.out_dir}/{params.sample}.html > {log} 2>&1
         """
@@ -336,7 +338,7 @@ rule make_config:
     output:
         join(dirs.OUT, 'final_reports', 'samples.csv'),
     params: 
-        fastq_dir = join(dirs.OUT, '3_error_removal'),
+        fastq_dir = join(dirs.OUT, '3_error_removal', 'bayeshammer' if config.get('error_correction', 'tadpole') == 'bayeshammer' else 'tadpole'),
         samples = SAMPLES,
         pre = join(dirs.OUT, 'final_reports', 'pre_multiqc_report.html'),
         post = join(dirs.OUT, 'final_reports', 'post_multiqc_report.html'),


### PR DESCRIPTION
### This pull request introduces two updates to the short-read quality control (QC) module.

**1. Add optional polyG tail trimming in filter_low_qual**
A new parameter _force_poly_g_ has been added in configs/parameters.yaml (under the filter_low_qual section) to allow trimming of polyG tails using the fastp option -g.
When _force_poly_g_: True, the Snakefile now adds the -g flag to the fastp command.
When _force_poly_g_: False or the parameter is not defined, the behavior remains unchanged.

**Changes made:**

configs/parameters.yaml: added

```
# --- filter_low_qual --- #
dedup: False
force_poly_g: True
```


workflow/Snakefile: updated rule filter_low_qual to include:

```
poly_g_flag = ('-g' if config.get('force_poly_g', False) else '')
...
{params.poly_g_flag} \
```

These changes enable optional trimming of polyG tails based on user-defined configuration.

**2. Fix output paths in make_config after error removal**

After the error removal step, corrected FASTQ files are stored in subfolders within 3_error_removal (either tadpole or bayeshammer), depending on the error correction method used.
Previously, the make_config rule still pointed samples.csv to files directly inside 3_error_removal/, which resulted in incorrect file paths in the final report (samples.csv final file ).

To address this issue, the make_config rule in the Snakefile was modified to dynamically detect the correct subdirectory based on the error_correction setting in the configuration file.

**Changes made:**

- `workflow/Snakefile`: updated the `params` section of `rule make_config` as follows:

 
```python
  fastq_dir = join(
      dirs.OUT,
      '3_error_removal',
      'bayeshammer' if config.get('error_correction', 'tadpole') == 'bayeshammer' else 'tadpole'
  ),
  samples = SAMPLES,
  pre = join(dirs.OUT, 'final_reports', 'pre_multiqc_report.html'),
  post = join(dirs.OUT, 'final_reports', 'post_multiqc_report.html'),

```
This ensures that the file samples.csv correctly references FASTQ file locations inside
3_error_removal/tadpole/ or 3_error_removal/bayeshammer/, depending on the configuration.